### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
   <a href="https://www.npmjs.com/package/agent-files"><img src="https://badgen.net/npm/dt/agent-files" alt="downloads"/></a>
   <a href="https://github.com/lirantal/agent-files/actions?workflow=CI"><img src="https://github.com/lirantal/agent-files/workflows/CI/badge.svg" alt="build"/></a>
   <a href="https://app.codecov.io/gh/lirantal/agent-files"><img src="https://badgen.net/codecov/c/github/lirantal/agent-files" alt="codecov"/></a>
-  <a href="https://snyk.io/test/github/lirantal/agent-files"><img src="https://snyk.io/test/github/lirantal/agent-files/badge.svg" alt="Known Vulnerabilities"/></a>
 </p>
 
 ## Features


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.