### PR TITLE
chore: ensure dependabot ecosystems carry "dependencies" and "automerge" labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "automerge"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
Adds the `dependencies` and `automerge` labels to any dependabot ecosystem entry that did not have them, so that auto-merge tooling picks up the dependabot PRs uniformly across all ecosystems (e.g. `github-actions`, `npm`).

No existing labels were modified — only entries lacking a `labels:` key got one inserted.