### PR TITLE
docs: add repository context docs 🤖🤖🤖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,19 +6,30 @@ Guidance for AI coding agents working in this repository.
 
 Before making changes, read:
 
-- `CONTRIBUTING.md` for PR expectations, tests, changesets, commit style, and agent-specific rules.
-- `RELEASE.md` for changeset and release workflow details.
-- `README.md` and relevant docs for user-facing behavior and project context.
+- `CONTRIBUTING.md` for contribution, PR, testing, commit, and agent-specific expectations.
+- `RELEASE.md` for release workflow details.
+- `README.md` for user-facing behavior, install/use examples, and package or app overview.
+- `docs/README.md` for the project documentation index.
+- `docs/development.md` for local setup and development workflows.
+- `docs/testing.md` for test strategy, commands, and verification expectations.
+- `docs/architecture.md` for project structure, boundaries, and important invariants.
+- `docs/conventions.md` for project-specific coding, documentation, and maintenance conventions.
 
 Treat those files as the source of truth. Do not duplicate or reinterpret their rules here.
 
-## Changesets
+## Documentation
 
-Before opening a PR, check `CONTRIBUTING.md#changesets`.
-Follow `RELEASE.md` for changeset creation steps.
+- Keep documentation in sync when changing behavior, public interfaces, workflows, architecture, configuration, or operational assumptions.
+- Put project-specific development details in `docs/`; keep root files focused on their standard audiences.
+- Prefer linking to the source of truth over duplicating long instructions across files.
+- When adding new docs, link them from `docs/README.md` and update this file only when they become important entry points for future agents.
 
 ## PRs and Issues
 
-Follow the agent labeling/title rules in `CONTRIBUTING.md`.
+- Follow PR, issue, and agent-labeling rules in `CONTRIBUTING.md`.
+- Use the issue-linking format specified in `CONTRIBUTING.md`.
 
-Use the issue-linking format specified in `CONTRIBUTING.md`.
+## Releases
+
+- Follow `RELEASE.md` for release workflow and changeset creation steps.
+- If this project uses changesets, treat `RELEASE.md` and any changeset guidance in `CONTRIBUTING.md` as authoritative.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ If any of the above doesn't work on a fresh checkout, that's a bug, please open 
 
 ### Environment setup
 
-Before making changes, use the project's devcontainer when possible so local tools, dependencies, and environment hooks match the expected setup. AI coding agents running from the host should follow the portless SSH workflow in [`.devcontainer/README.md`](.devcontainer/README.md#coding-agents-over-ssh) to start or reuse the devcontainer, configure the SSH alias, and select the mounted repository folder.
+Before making changes, use the repository's documented development environment so local tools, dependencies, and environment hooks match the expected setup.
 
 ### Release readiness
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ For detailed information about the project architecture and features:
 - **[Requirements](./docs/requirements.md)**: Functional and non-functional requirements
 - **[ESLint 10 Migration Plan](./docs/migration-eslint-10.md)**: Upgrade and migration checklist for contributors
 
+## Documentation
+
+- [Project documentation](./docs/README.md) - development, testing, architecture, and conventions.
+
 ## Contributing
 
 Please consult [CONTRIBUTING](./CONTRIBUTING.md) for guidelines on contributing to this project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# agent-files Documentation
+
+This directory contains project documentation for maintainers and coding agents.
+
+## Core Docs
+
+- [Development](./development.md) - local setup, workflows, and useful commands.
+- [Testing](./testing.md) - test commands, test organization, and verification expectations.
+- [Architecture](./architecture.md) - repository structure, package boundaries, and important flows.
+- [Conventions](./conventions.md) - coding, documentation, and maintenance conventions.
+
+## Root References
+
+- [Project README](../README.md) - user-facing overview, installation, and usage.
+- [Contributing](../CONTRIBUTING.md) - issue, PR, commit, and agent expectations.
+- [Release](../RELEASE.md) - Changesets and release workflow.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture
+
+## Overview
+
+agent-files package description: A library that provides, detects and parses files used by coding agents and other AI tools so you don't have to reinvent the track them yourself.
+
+## Repository Structure
+
+- `package.json` - root package scripts and dependency metadata.
+- `.changeset/` - Changesets configuration and pending release notes.
+- `docs/` - project documentation for maintainers and coding agents.
+
+## Boundaries
+
+- Keep user-facing usage, installation, and examples in the root `README.md`.
+- Keep contribution rules in `CONTRIBUTING.md`.
+- Keep release workflow details in `RELEASE.md`.
+- Keep deeper development and architecture notes in `docs/`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,20 @@
+# Conventions
+
+## Commits and PRs
+
+- Use Conventional Commits for commit messages.
+- Keep PRs focused on one logical change.
+- Include a Changeset for release-worthy package behavior changes.
+- Agent-authored PRs should follow the repository's agent title marker guidance in `CONTRIBUTING.md`.
+
+## Documentation
+
+- Keep root `README.md` focused on users and package consumers.
+- Put maintainer and agent context in `docs/`.
+- Link new documentation from `docs/README.md`.
+
+## Code
+
+- Prefer the existing package structure and scripts over introducing new tooling.
+- Keep generated files, dependency folders, and build output out of commits.
+- Match formatting and lint expectations already configured in the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,22 @@
+# Development
+
+## Prerequisites
+
+- Node.js compatible with this repository's packages and tooling.
+- npm for dependency installation and scripts.
+
+## Setup
+
+```sh
+npm install
+```
+
+## Common Commands
+
+- `pnpm build` - builds the project.
+- `pnpm lint` - runs lint checks.
+- `pnpm test` - runs the test suite.
+
+## Repository Notes
+
+This repository is organized around the root package `agent-files`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,31 @@
+# Testing
+
+## Test Command
+
+Run the test suite with:
+
+```sh
+npm run test
+```
+
+## Linting
+
+Run lint checks with:
+
+```sh
+npm run lint
+```
+
+## Markdown
+
+Run Markdown linting with:
+
+```sh
+npm run lint:markdown
+```
+
+## Expectations
+
+- Add or update tests for behavior changes.
+- Run the relevant package-level checks before opening a PR.
+- Keep generated coverage, build output, and dependency folders out of commits.


### PR DESCRIPTION
Adds standardized repository context for coding agents and maintainers:

- refreshes AGENTS.md with the shared routing template
- adds or links canonical docs for development, testing, architecture, and conventions
- adds RELEASE.md where missing for Changesets release guidance

No package behavior changes are included.