### PR TITLE
fix: resolve TypeScript imports in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,9 @@ export default defineConfig([
       'n/no-process-exit': 'warn',
       'n/no-unsupported-features': 'off',
       'n/no-unpublished-require': 'off',
+      'n/no-missing-import': ['error', {
+        typescriptExtensionMap: [['.ts', '.js'], ['.tsx', '.js']]
+      }],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       'security/detect-non-literal-fs-filename': 'off',


### PR DESCRIPTION
The grouped dev-dependency update raises eslint-plugin-n to v18, whose no-missing-import rule needs the repository’s .js-to-.ts import mapping. Configure the supported TypeScript extension map so lint accepts NodeNext TypeScript imports. Verified with npm ci and npm run lint in Node 24.